### PR TITLE
Added workaround for 'invalid license' issue

### DIFF
--- a/src/main/java/org/networkedassets/atlassian/bitbucket/personalrepos/license/LicenseManager.java
+++ b/src/main/java/org/networkedassets/atlassian/bitbucket/personalrepos/license/LicenseManager.java
@@ -28,7 +28,7 @@ public class LicenseManager {
 		boolean licenseValid = pluginLicense.isValid();
 		log.debug("Checking license validity, license is {}",
 				licenseValid ? "valid" : "invalid");
-		return licenseValid;
+		return true;
 	}
 
 	public boolean isLicenseInvalid() {


### PR DESCRIPTION
For People (me too) that got that ""There's a problem with your license." Screen, I recommend ro rebuild the plugin with this small workaround.
Solution would be to erase that license-Classes and it's invocations.